### PR TITLE
fix: enforces jira prefix if `jira_project_issue_prefix` not present in `pyproject.toml`

### DIFF
--- a/cz_bitbucket_jira_plugin/main.py
+++ b/cz_bitbucket_jira_plugin/main.py
@@ -51,6 +51,7 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'name': 'issue_prefix',
                 'message': "What's the jira prefix?",
                 'instruction': default_prefix,
+                'validate': required_answer_validator if not self.project_prefix else None,
                 'qmark': ' '
             },
             {


### PR DESCRIPTION
If `jira_project_issue_prefix = "LAB"`:

![Screenshot from 2024-04-23 22-08-39](https://github.com/marcosdotme/cz-bitbucket-jira-plugin/assets/48416792/308bbb91-2134-4701-9683-48b6ab278fd8)

<br/>

If `jira_project_issue_prefix` not present:

![Screenshot from 2024-04-23 22-09-19](https://github.com/marcosdotme/cz-bitbucket-jira-plugin/assets/48416792/d87ea1ea-ae54-4415-98e3-7a7c9714c1fb)
