### PR TITLE
fix: display indicator of required answer when `jira_project_issue_prefix` key is missing on pyproject.toml

### DIFF
--- a/cz_bitbucket_jira_plugin/main.py
+++ b/cz_bitbucket_jira_plugin/main.py
@@ -58,7 +58,7 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'message': "What's the jira prefix?",
                 'instruction': default_prefix,
                 'validate': required_answer_validator if not self.project_prefix else None,
-                'qmark': ' '
+                'qmark': ' ' if self.project_prefix else '\n*'
             },
             {
                 'type': 'input',


### PR DESCRIPTION
Now we have the "*" indicator:

![image](https://github.com/marcosdotme/cz-bitbucket-jira-plugin/assets/48416792/301d558a-3066-4dac-8f6c-1813e2acaa25)

closes #17 