### PR TITLE
feat: enable plugin configuration via `.cz.toml` or `pyproject.toml`

### DIFF
--- a/cz_bitbucket_jira_plugin/functions.py
+++ b/cz_bitbucket_jira_plugin/functions.py
@@ -1,8 +1,33 @@
+from pathlib import Path
+
 import tomli
 
 
+def config_file_is_valid(config_file: str | Path) -> bool:
+    with open(config_file, mode='rb') as file:
+        data = tomli.load(file)
+
+        try:
+            data['tool']['commitizen']
+            return True
+        except KeyError:
+            return False
+
+
+def get_config_file() -> Path:
+    config_files = [Path('pyproject.toml'), Path('.cz.toml')]
+
+    for config_file in config_files:
+        if config_file_is_valid(config_file=config_file):
+            return config_file
+    
+    raise AttributeError('Missing [tool.commitizen] block on your config file.')
+
+
 def get_user_prompt_style():
-    with open('./pyproject.toml', mode='rb') as file:
+    config_file = get_config_file()
+
+    with open(config_file, mode='rb') as file:
         data = tomli.load(file)
 
         try:


### PR DESCRIPTION
closes #19 