### PR TITLE
delete: remove pre-commit hook 'no-commit-to-branch'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,6 @@ repos:
     -   id: end-of-file-fixer
         name: add-empty-line-to-end-of-file
 
-    -   id: no-commit-to-branch
-        name: no-commit-to-branch
-        args: [--branch, main]
-
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:


### PR DESCRIPTION
The rule that disable direct pushes to `main` was set on Github, because this hook are failing after merge the pull request.