### PR TITLE
fix: `apply_multiple_validators` function was not working after run `ruff-check` hook

### DIFF
--- a/cz_bitbucket_jira_plugin/validators.py
+++ b/cz_bitbucket_jira_plugin/validators.py
@@ -40,7 +40,7 @@ def apply_multiple_validators(validators: List[Callable]):
         for validator in validators:
             result = validator(answer)
 
-            if not result:
+            if result != True: # noqa: E712
                 return result
 
         return True


### PR DESCRIPTION
Ruff changed the comparison `if result != True` to `if not result`.

In most of the cases this makes sense and it's more 'pythonic', but in our scenario, the `result` variable will not be ever an boolean, sometimes it's an string containing the error message, and while this variable its not `True` we keep printing the error message to user, forcing him to fix the error. When the error is fixed, `result` variable stores an boolean `True` So that the why we need to check if its `not True`.

closes #42 