### PR TITLE
feat: make the file `.cz.toml` more prioritized than `pyproject.toml`

### DIFF
--- a/cz_bitbucket_jira_plugin/functions.py
+++ b/cz_bitbucket_jira_plugin/functions.py
@@ -17,7 +17,7 @@ def config_file_is_valid(config_file: str | Path) -> bool:
 
 
 def get_config_file() -> Path:
-    config_files = [Path('pyproject.toml'), Path('.cz.toml')]
+    config_files = [Path('.cz.toml'), Path('pyproject.toml')]
     any_config_file_exists = any([file.exists() for file in config_files])
 
     if not any_config_file_exists:


### PR DESCRIPTION
Because if we have an **specific** config file for an **specific** tool, this file is important. Right?

closes #46 