### PR TITLE
fix: enforces `commit type`  prompt be required

### DIFF
--- a/cz_bitbucket_jira_plugin/exceptions.py
+++ b/cz_bitbucket_jira_plugin/exceptions.py
@@ -1,0 +1,16 @@
+from prompt_toolkit.validation import ValidationError
+
+
+class RequiredAnswerException(ValidationError):
+    def __init__(self):
+        super().__init__(cursor_position=0, message='Answer is required.')
+
+
+class ValueMustBeIntegerException(ValidationError):
+    def __init__(self):
+        super().__init__(cursor_position=0, message='Value must be integer.')
+
+
+class AllValuesMustBeIntegerException(ValidationError):
+    def __init__(self):
+        super().__init__(cursor_position=0, message='All values must be integer.')

--- a/cz_bitbucket_jira_plugin/main.py
+++ b/cz_bitbucket_jira_plugin/main.py
@@ -7,10 +7,10 @@ from commitizen.defaults import Questions
 from .constants import DEFAULT_COMMIT_TYPES
 from .constants import DEFAULT_PROMPT_STYLE
 from .functions import get_user_prompt_style
-from .validators import all_values_must_be_integer_validator
+from .validators import AllValuesMustBeIntegerValidator
 from .validators import apply_multiple_validators
-from .validators import must_be_integer_validator
-from .validators import required_answer_validator
+from .validators import RequiredAnswerValidator
+from .validators import ValueMustBeIntegerValidator
 
 
 class CzBitbucketJiraPlugin(BaseCommitizen):
@@ -47,7 +47,7 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'message': "What's the Jira project key?",
                 'instruction': default_jira_project_key,
                 'validate': (
-                    required_answer_validator if not self.user_jira_project_key else None
+                    RequiredAnswerValidator if not self.user_jira_project_key else None
                 ),
                 'qmark': ' ' if self.user_jira_project_key else '\n*',
             },
@@ -55,7 +55,7 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'type': 'input',
                 'name': 'issue_epic_number',
                 'message': 'Issue epic number:\n ',
-                'validate': must_be_integer_validator,
+                'validate': ValueMustBeIntegerValidator,
                 'qmark': '\n ',
             },
             {
@@ -64,8 +64,8 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'message': 'Issue number:\n ',
                 'validate': apply_multiple_validators(
                     validators=[
-                        required_answer_validator,
-                        must_be_integer_validator,
+                        RequiredAnswerValidator,
+                        ValueMustBeIntegerValidator,
                     ]
                 ),
                 'qmark': '\n*',
@@ -75,7 +75,7 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'name': 'issue_subtasks',
                 'message': 'Issue subtask number:\n',
                 'instruction': multiple_items_instruction,
-                'validate': all_values_must_be_integer_validator,
+                'validate': AllValuesMustBeIntegerValidator,
                 'qmark': '\n ',
             },
             {
@@ -83,7 +83,7 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'name': 'issue_related_tasks',
                 'message': 'Issue related task number:\n',
                 'instruction': multiple_items_instruction,
-                'validate': all_values_must_be_integer_validator,
+                'validate': AllValuesMustBeIntegerValidator,
                 'qmark': '\n ',
             },
             {
@@ -93,13 +93,14 @@ class CzBitbucketJiraPlugin(BaseCommitizen):
                 'choices': self.commit_types,
                 'pointer': '>',
                 'instruction': select_instruction,
+                'validator': RequiredAnswerValidator,
                 'qmark': '\n*',
             },
             {
                 'type': 'input',
                 'name': 'commit_title',
                 'message': 'Commit title:\n ',
-                'validate': required_answer_validator,
+                'validate': RequiredAnswerValidator,
                 'qmark': '\n*',
             },
             {


### PR DESCRIPTION
The only workaround for this, since the Questionary 'select' prompt type havent an `validate` argument, was pass and kwarg called `validator`. That kwarg is internally passed to `prompt_toolkit.PromptSession` that has an `validator` argument and this argument expects an class with an `validate` method.

So for keep the consistency on the code based I converted all validators to classes with an `validate` method.

closes #11 